### PR TITLE
FEATURE: Centralize lazyness controll to fusion prototypes and add Sitegeist.Lazybones:Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,10 @@ optional props to control the lazy loading.
 See: https://github.com/sitegeist/Sitegeist.Kaleidoscope#sitegeistkaleidoscopeimage
 
 Props:
-- `lazy`: Enable lazy loading (boolean, default true).
-   Use this to control whether contents should be lazy loaded or not. If this value
-   is false the `Sitegeist.Kaleidoscope:Image` is used directly.
-- `lazyClass`: The class to attach to the img-tags (string, default "lazyload").
-   Has to fit your js-library.
-- `lazyWidth`: The width of the thumbnail src that is loaded first (int, default null).
-   If this value is null no initial src is rendered to avoid any unneeded http-requests.
+- `lazy`: Enable lazy loading (boolean, defaults to `Sitegeist.Lazybones:Lazy.Enabled`)
+- `lazyClass`: The class to attach to the img-tags (string, defaults to `Sitegeist.Lazybones:Lazy.ClassName`)
+- `lazyWidth`: The width of the thumbnail-src that is loaded first  (string, defaults to `Sitegeist.Lazybones:Lazy.Width`)
+
 
 Props from `Sitegeist.Kaleidoscope:Image`:
 - `imageSource`: the imageSource to render
@@ -79,18 +76,15 @@ optional props to control the lazy loading.
 See: https://github.com/sitegeist/Sitegeist.Kaleidoscope#sitegeistkaleidoscopepicture
 
 Props:
-- `lazy`: Enable lazy loading (boolean, default true).
-   Use this to control whether contents should be lazy loaded or not. If this value
-   is false the `Sitegeist.Kaleidoscope:Picture` is used directly.
-- `lazyClass`: The class to attach to the img-tags (string, default "lazyload").
-   Has to fit your js-library.
-- `lazyWidth`: The width of the thumbnail-src that is loaded first (int, default null).
-   If this value is null no initial src is rendered to avoid any unneeded http-requests.
+- `lazy`: Enable lazy loading (boolean, defaults to `Sitegeist.Lazybones:Lazy.Enabled`)
+- `lazyClass`: The class to attach to the img-tags (string, defaults to `Sitegeist.Lazybones:Lazy.ClassName`)
+- `lazyWidth`: The width of the thumbnail-src that is loaded first  (string, defaults to `Sitegeist.Lazybones:Lazy.Width`)
 
 Props from `Sitegeist.Kaleidoscope:Picture`:
 - `imageSource`: the imageSource to render
 - `sources`: an array of source definitions that supports the following keys
    - `media`: the media query of this source
+   - `type`: the type of this source
    - `imageSource`: alternate image-source for art direction purpose
    - `srcset`: media descriptors like '1.5x' or '600w' (string ot array)
    - `sizes`: sizes attribute (string ot array)
@@ -99,6 +93,39 @@ Props from `Sitegeist.Kaleidoscope:Picture`:
 - `alt`: alt-attribute for the picture tag
 - `title`: title attribute for the picture tag
 - `class`: class attribute for the picture tag
+
+
+### `Sitegeist.Lazybones:Source`
+
+Render a source-tag with optional srcset based on sizes or resolutions.
+
+This prototype is a drop in replacement for `Sitegeist.Kaleidoscope:Source` with
+optional props to control the lazy loading.
+
+Props:
+- `lazy`: Enable lazy loading (boolean, defaults to `Sitegeist.Lazybones:Lazy.Enabled`)
+
+Props from `Sitegeist.Kaleidoscope:Source`:
+- `imageSource`: the imageSource to render
+- `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array)
+- `sizes`: sizes attribute of the default image (string or array)
+- `media`: the media query of this source
+- `type`: the type of this source
+
+### `Sitegeist.Lazybones:Lazy.Enabled`
+
+Boolean value prototype with default value `true` that defines whether lazyness is enabled or not.
+Override the `value` of this prototype globally or for specific parts of your fusion. 
+
+### `Sitegeist.Lazybones:Lazy.ClassName`
+
+String value prototype with default value `lazyload` to define the class that marks lazyloaded images.
+Override the `value` of this prototype globally or for specific parts of your fusion. 
+
+### `Sitegeist.Lazybones:Lazy.Width`
+
+Integer value prototype with default value `null` to define the size of lowres images that are loaded as 
+placeholders. Override zhe `value` of this prototype globally or for specific parts of your fusion. 
 
 ## Dynamically enable/disable the lazy rendering
 
@@ -109,11 +136,14 @@ content = Neos.Neos:ContentCollection {
     nodePath = 'main'
     content.iterationName = 'mainContentIterator'
 
-    prototype(Sitegeist.Lazybones:Picture) {
-        lazy = ${!mainContentIterator.isFirst}
+    // enable lazynes for all but first content 
+    prototype(Sitegeist.Lazybones:Lazy.Enabled) {
+        value = ${!mainContentIterator.isFirst}
     }
-    prototype(Sitegeist.Lazybones:Image) {
-        lazy = ${!mainContentIterator.isFirst}
+    
+    // preload 150px variants of the images 
+    prototype(Sitegeist.Lazybones:Lazy.Width) {
+        value = 150
     }
 }
 ```

--- a/Resources/Private/Fusion/Prototypes/Image.fusion
+++ b/Resources/Private/Fusion/Prototypes/Image.fusion
@@ -38,9 +38,9 @@ prototype(Sitegeist.Lazybones:Image) < prototype(Neos.Fusion:Component) {
         imageSource = ${PropTypes.instanceOf('\\Sitegeist\\Kaleidoscope\\EelHelpers\\ImageSourceHelperInterface')}
     }
 
-    lazy = true
-    lazyClass = "lazyload"
-    lazyWidth = null
+    lazy = Sitegeist.Lazybones:Lazy.Enabled
+    lazyClass = Sitegeist.Lazybones:Lazy.ClassName
+    lazyWidth = Sitegeist.Lazybones:Lazy.Width
 
     imageSource = null
     srcset = null
@@ -72,14 +72,9 @@ prototype(Sitegeist.Lazybones:Image) < prototype(Neos.Fusion:Component) {
 
         default {
             condition = true
-            renderer = Sitegeist.Kaleidoscope:Image {
-                imageSource = ${props.imageSource}
-                srcset = ${props.srcset}
-                sizes = ${props.sizes}
-                alt = ${props.alt}
-                title = ${props.title}
-                class = ${props.class}
-            }
+            renderer = afx`
+                <Sitegeist.Kaleidoscope:Image {...props} />
+            `
         }
     }
 }

--- a/Resources/Private/Fusion/Prototypes/Lazy/ClassName.fusion
+++ b/Resources/Private/Fusion/Prototypes/Lazy/ClassName.fusion
@@ -1,0 +1,3 @@
+prototype(Sitegeist.Lazybones:Lazy.ClassName) < prototype(Neos.Fusion:Value) {
+    value = 'lazyload'
+}

--- a/Resources/Private/Fusion/Prototypes/Lazy/Enabled.fusion
+++ b/Resources/Private/Fusion/Prototypes/Lazy/Enabled.fusion
@@ -1,0 +1,3 @@
+prototype(Sitegeist.Lazybones:Lazy.Enabled) < prototype(Neos.Fusion:Value) {
+    value = true
+}

--- a/Resources/Private/Fusion/Prototypes/Lazy/Width.fusion
+++ b/Resources/Private/Fusion/Prototypes/Lazy/Width.fusion
@@ -1,0 +1,3 @@
+prototype(Sitegeist.Lazybones:Lazy.Width) < prototype(Neos.Fusion:Value) {
+    value = null
+}

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -23,9 +23,9 @@ prototype(Sitegeist.Lazybones:Picture) < prototype(Neos.Fusion:Component) {
         }
     }
 
-    lazy = true
-    lazyClass = "lazyload"
-    lazyWidth = null
+    lazy = Sitegeist.Lazybones:Lazy.Enabled
+    lazyClass = Sitegeist.Lazybones:Lazy.ClassName
+    lazyWidth = Sitegeist.Lazybones:Lazy.Width
 
     imageSource = Sitegeist.Kaleidoscope:DummyImageSource
     srcset = null
@@ -42,12 +42,13 @@ prototype(Sitegeist.Lazybones:Picture) < prototype(Neos.Fusion:Component) {
             renderer = afx`
                 <picture @if.has={props.imageSource} class={props.class ? props.class + ' ' + props.lazyClass : props.lazyClass }>
                     <Neos.Fusion:Collection collection={props.sources} itemName="source" @children="itemRenderer" @if.has={props.sources}>
-                        <source
-                            @context.subImageSource={source.imageSource ? source.imageSource : props.imageSource}
+                        <Sitegeist.Lazybones:Source
+                            lazy={props.lazy}
+                            imageSource={source.imageSource ? source.imageSource : props.imageSource}
+                            type={source.type}
                             media={source.media}
-                            data-srcset={source.srcset ? subImageSource.srcset(source.srcset) : subImageSource.src()}
-                            data-sizes={source.sizes}
-                            data-sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
+                            srcset={source.srcset ? source.srcset : props.srcset}
+                            sizes={source.sizes ? source.sizes : props.sizes}
                         />
                     </Neos.Fusion:Collection>
                     <Sitegeist.Lazybones:Image
@@ -67,15 +68,9 @@ prototype(Sitegeist.Lazybones:Picture) < prototype(Neos.Fusion:Component) {
 
         default {
             condition = true
-            renderer = Sitegeist.Kaleidoscope:Picture {
-                imageSource = ${props.imageSource}
-                srcset = ${props.srcset}
-                sizes = ${props.sizes}
-                sources = ${props.sources}
-                alt = ${props.alt}
-                title = ${props.title}
-                class = ${props.class}
-            }
+            renderer = afx`
+                <Sitegeist.Kaleidoscope:Picture {...props} />
+            `
         }
     }
 }

--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -1,0 +1,37 @@
+prototype(Sitegeist.Lazybones:Source) < prototype(Neos.Fusion:Component) {
+    @propTypes {
+        imageSource = ${PropTypes.instanceOf('\\Sitegeist\\Kaleidoscope\\EelHelpers\\ImageSourceHelperInterface')}
+    }
+
+    lazy = Sitegeist.Lazybones:Lazy.Enabled
+
+    imageSource = null
+    type = null
+    media = null
+    srcset = null
+    sizes = null
+
+    renderer = Neos.Fusion:Case {
+
+        lazy {
+            condition = ${props.lazy}
+            renderer = afx`
+                <source @if.has={props.imageSource}
+                    media={props.media}
+                    type={props.type}
+                    data-srcset={props.imageSource.srcset(props.srcset)}
+                    data-srcset.@if.has={props.srcset}
+                    data-sizes={props.sizes}
+                    data-sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
+                />
+            `
+        }
+
+        default {
+            condition = true
+            renderer = afx`
+                <Sitegeist.Kaleidoscope:Source {...props} />
+            `
+        }
+    }
+}

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,1 +1,1 @@
-include: Prototypes/*.fusion
+include: **/*.fusion

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "name": "sitegeist/lazybones",
     "license": "GPL-3.0-or-later",
     "require": {
-        "sitegeist/kaleidoscope": "^3.2"
+        "neos/neos": "^4.3 || ^5.0 || dev-master",
+        "neos/fusion-afx": "^1.2",
+        "sitegeist/kaleidoscope": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Three newFusion prototypes now allow central control of lazyness

- `Sitegeist.Lazybones:Lazy.Enabled` default `value` is `true`
- `Sitegeist.Lazybones:Lazy.Classname` default `value` is `lazyload`
- `Sitegeist.Lazybones:Lazy.Width` default `value` is `null`

The prototype `Sitegeist.Lazybones:Source` can render a source with srcset sizes type and media and is internally used in `Sitegeist.Lazybones:Picture` 

The Neos version requirement is raised to version 4.3 as versions before cannot support format. Also Neos 5 is now allowed.