### PR TITLE
TASK: Always render sizes in picture sources

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -21,8 +21,8 @@ prototype(Sitegeist.Lazybones:Source) < prototype(Neos.Fusion:Component) {
                     type={props.type}
                     data-srcset={props.imageSource.srcset(props.srcset)}
                     data-srcset.@if.has={props.srcset}
-                    data-sizes={props.sizes}
-                    data-sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
+                    sizes={props.sizes}
+                    sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
                 />
             `
         }


### PR DESCRIPTION
This is necessary as lazysizes will only replace masked sizes in img-elements