### PR TITLE
BUGFIX: Lazy pictures should not render the source src in full quality

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -85,7 +85,7 @@ prototype(Sitegeist.Lazybones:Picture) < prototype(Neos.Fusion:Component) {
                         {props.content}
                         <Neos.Fusion:Collection collection={props.sources} itemName="source" @if.has={props.sources}>
                             <Sitegeist.Lazybones:Source
-                                lazy={props.lazy}
+                                lazy
                                 imageSource={source.imageSource ? source.imageSource : props.imageSource}
                                 type={source.type}
                                 media={source.media}


### PR DESCRIPTION
Since the props is not given down to the subsequent renderer the value becomes false.