### PR TITLE
FEATURE: Support alt and title from image source as it was introduced in Kaleidoscope 6.1.0

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Image.fusion
+++ b/Resources/Private/Fusion/Prototypes/Image.fusion
@@ -45,7 +45,7 @@ prototype(Sitegeist.Lazybones:Image) < prototype(Neos.Fusion:Component) {
     imageSource = null
     srcset = null
     sizes = null
-    alt = ''
+    alt = null
     title = null
     class = null
     width = null
@@ -94,8 +94,8 @@ prototype(Sitegeist.Lazybones:Image) < prototype(Neos.Fusion:Component) {
                         height={props.renderDimensionAttributes ? props.imageSource.currentHeight : null}
 
                         class={props.class ? props.class + ' ' + props.lazyClass : props.lazyClass}
-                        alt={props.alt}
-                        title={props.title}
+                        alt={props.alt || props.imageSource.alt() || ''}
+                        title={props.title || props.imageSource.title()}
                     />
                 `
             }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-or-later",
     "require": {
         "neos/fusion-afx": "^1.2 || ^7.0 || dev-master",
-        "sitegeist/kaleidoscope": "^6.0 || dev-master"
+        "sitegeist/kaleidoscope": "^6.1 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
see: https://github.com/sitegeist/Sitegeist.Kaleidoscope/releases/tag/v6.1.0