### PR TITLE
FEATURE: Add setting to control default lazyness behavior

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,3 +3,7 @@ Neos:
     fusion:
       autoInclude:
         Sitegeist.Lazybones: true
+Sitegeist:
+  Lazybones:
+    default:
+      lazyEnabled: true

--- a/Configuration/VisualRegressionTesting/Settings.yaml
+++ b/Configuration/VisualRegressionTesting/Settings.yaml
@@ -1,0 +1,4 @@
+Sitegeist:
+  Lazybones:
+    default:
+      lazyEnabled: false

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ by our employer http://www.sitegeist.de.*
 Sitegeist.Lazybones is available via packagist run `composer require sitegeist/lazybones`.
 We use semantic-versioning so every breaking change will increase the major-version number.
 
+## Settings 
+
+The default-lazyness is controlled by the setting 'Sitegeist.Lazybones.default.lazyEnabled' 
+and is active by default except in `FLOW_CONTEXT=Development/VisualRegressionTesting`.
+
+```
+Sitegeist:
+  Lazybones:
+    default:
+      lazyEnabled: true
+```
+
 ## Usage
 
 ### LazyloadJS
@@ -128,6 +140,9 @@ Props from `Sitegeist.Kaleidoscope:Source`:
 
 Boolean value prototype with default value `true` that defines whether lazyness is enabled or not.
 Override the `value` of this prototype globally or for specific parts of your fusion. 
+
+NOTE: The default value comes from the configuration 'Sitegeist.Lazybones.default.lazyEnabled' and is active by default 
+except in `FLOW_CONTEXT=Development/VisualRegressionTesting`.
 
 ### `Sitegeist.Lazybones:Lazy.ClassName`
 

--- a/Resources/Private/Fusion/Prototypes/Lazy/Enabled.fusion
+++ b/Resources/Private/Fusion/Prototypes/Lazy/Enabled.fusion
@@ -1,3 +1,3 @@
 prototype(Sitegeist.Lazybones:Lazy.Enabled) < prototype(Neos.Fusion:Value) {
-    value = true
+    value = ${Configuration.setting('Sitegeist.Lazybones.default.lazyEnabled')}
 }


### PR DESCRIPTION
The setting allows to control the default lazyness and is usually enabled

```
Sitegeist:
  Lazybones:
    default:
      lazyEnabled: true
```

For `FLOW_CONTEXT=Development/VisualRegressionTesting`  the setting is
disabled as lazy loading does slow down regression tests and tends to make them
less deterministic.