### PR TITLE
BUGFIX: Apply `width` and `height` for `Sitegeist.Lazybones:Picture` with `formats`

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -101,7 +101,10 @@ prototype(Sitegeist.Lazybones:Picture) < prototype(Neos.Fusion:Component) {
                             collection={Type.isArray(props.formats) ? props.formats : String.split(props.formats, ',')}
                             itemName="format"
                         >
-                            <Sitegeist.Lazybones:Source format={String.trim(format)} />
+                            <Sitegeist.Lazybones:Source
+                                imageSource={props.imageSource}
+                                format={String.trim(format)}
+                                />
                         </Neos.Fusion:Collection>
                         <Sitegeist.Lazybones:Image
                             lazy


### PR DESCRIPTION
Apply `width` and `height` constraints defined for the main element to the items when the `formats` option is used to render multiple formats in `Sitegeist.Lazybones:Picture`